### PR TITLE
Ability to specify distribution groups

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -40,11 +40,11 @@ workflows:
           file if you would not specify another value.
         run_if: true
         inputs:
-        - appcenter_name: profiles
-        - appcenter_org: szymon.nn
-        - artifact_path: "../app-release.apk"
+        - appcenter_name: TestName
+        - appcenter_org: TestOrg
+        - artifact_path: "../step.sh"
         - release_notes: "Test release notes"
-        - distribution_groups: "test"
+        - distribution_groups: "TestGroup1, TestGroup2"
     - script:
         inputs:
         - content: |

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -40,10 +40,11 @@ workflows:
           file if you would not specify another value.
         run_if: true
         inputs:
-        - appcenter_name: TestName
-        - appcenter_org: TestOrg
-        - artifact_path: "../step.sh"
+        - appcenter_name: profiles
+        - appcenter_org: szymon.nn
+        - artifact_path: "../app-release.apk"
         - release_notes: "Test release notes"
+        - distribution_groups: "test"
     - script:
         inputs:
         - content: |

--- a/step.sh
+++ b/step.sh
@@ -131,6 +131,9 @@ RELEASE_ID=$(cat "${TMPFILE}" | jq .release_id --raw-output)
 echo_details "result is ${STATUSCODE}: $(cat ${TMPFILE})"
 rm "${TMPFILE}"
 
+IFS=', ' read -r -a DISTRIBUTION_GROUPS <<< $distribution_groups
+if [ ${#DISTRIBUTION_GROUPS[@]} -eq 0 ]
+then
 echo_info "Retrieving distribution groups for ${appcenter_name}"
 TMPFILE=$(mktemp)
 STATUSCODE=$(curl \
@@ -150,8 +153,9 @@ SAVEIFS="${IFS}"
 IFS=$'\n'
 DISTRIBUTION_GROUPS=( $(cat "${TMPFILE}" | jq '.[].name' --raw-output) )
 IFS="${SAVEIFS}"
-echo_details "distribution groups are ${DISTRIBUTION_GROUPS[*]}"
 rm "${TMPFILE}"
+fi
+echo_details "distribution groups are ${DISTRIBUTION_GROUPS[*]}"
 
 for DISTRIBUTION_GROUP in "${DISTRIBUTION_GROUPS[@]}"
 do

--- a/step.yml
+++ b/step.yml
@@ -63,7 +63,7 @@ toolkit:
     entry_file: step.sh
 
 inputs:
-  - appcenter_api_token:  $APPCENTER_API_TOKEN
+  - appcenter_api_token: $APPCENTER_API_TOKEN
     opts:
       title: AppCenter API Token
       is_expand: true
@@ -84,6 +84,12 @@ inputs:
       title: "path to the built application file (.ipa or .apk)"
       is_expand: true
       is_required: true
+  - distribution_groups: $DISTRIBUTION_GROUPS
+    opts:
+      title: "AppCenter distribution groups"
+      description: "Groups should be comma separated e.g. group1, group2. If not specified, artifact will be sent to all distribution groups"
+      is_expand: true
+      is_required: false
   - release_notes: $RELEASE_NOTES
     opts:
       title: "Uploaded build related release notes"


### PR DESCRIPTION
User can specify a comma-separated list of distribution groups that will be used. If the parameter is not specified artifact will be sent to all distribution groups.