### PR TITLE
Add new parameter `notify_testers` to control if testers should be notified within new release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a "step" for the [Bitrise](https://www.bitrise.io/) CI/CD service that p
 
 * release_notes - release notes to include with this release
 * distribution_groups - comma-separated list of distribution groups to release it to.  If not set, it will release it to all associated distribution groups
+* notify_testers - a boolean which determines whether to notify testers of a new release
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ This is a "step" for the [Bitrise](https://www.bitrise.io/) CI/CD service that p
 * appcenter_name - name of the app on AppCenter
 * appcenter_org - AppCenter organization that owns the app
 * artifact_path - the full path of the `.ipa` or `.apk` file
+* notify_testers - a boolean which determines whether to notify testers of a new release
 
 ## Optional variables
 
 * release_notes - release notes to include with this release
 * distribution_groups - comma-separated list of distribution groups to release it to.  If not set, it will release it to all associated distribution groups
-* notify_testers - a boolean which determines whether to notify testers of a new release
 
 ## Troubleshooting
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -45,6 +45,7 @@ workflows:
         - artifact_path: "../step.sh"
         - release_notes: "Test release notes"
         - distribution_groups: "TestGroup1, TestGroup2"
+        - notify_testers: true
     - script:
         inputs:
         - content: |

--- a/step.sh
+++ b/step.sh
@@ -167,7 +167,7 @@ do
 		--header "X-API-Token: ${appcenter_api_token}" \
 		--silent --show-error \
 		--output /dev/stderr --write-out "%{http_code}" \
-		-d "{ \"destination_name\": \"${DISTRIBUTION_GROUP}\", \"release_notes\": \"${release_notes:-}\"}" \
+		-d "{ \"destination_name\": \"${DISTRIBUTION_GROUP}\", \"release_notes\": \"${release_notes:-}\", \"notify_testers\": ${notify_testers}}" \
 		"https://api.appcenter.ms/v0.1/apps/${appcenter_org}/${appcenter_name}/releases/${RELEASE_ID}" \
 		2> "${TMPFILE}")
 

--- a/step.yml
+++ b/step.yml
@@ -95,3 +95,10 @@ inputs:
       title: "Uploaded build related release notes"
       is_expand: true
       is_required: false
+  - notify_testers: true
+    opts:
+      title: "Notify testers?"
+      summary: "True if you want to notify testers of a new release"
+      value_options: ["true", "false"]
+      is_expand: true
+      is_required: true


### PR DESCRIPTION
I have tested it with `bitrise run test` command.