### PR TITLE
Sanitizing JSON in release_notes parameter

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -157,6 +157,10 @@ rm "${TMPFILE}"
 fi
 echo_details "distribution groups are ${DISTRIBUTION_GROUPS[*]}"
 
+echo "{\"r\":\"${release_notes:-}\"}" >> TMP_RELEASE_NOTES.notjson
+RELEASE_NOTES_SANITIZED=( $(echo $(<TMP_RELEASE_NOTES.notjson) | jq -r '.r') )
+rm TMP_RELEASE_NOTES.notjson
+
 for DISTRIBUTION_GROUP in "${DISTRIBUTION_GROUPS[@]}"
 do
 	echo_info "Adding to distribution group ${DISTRIBUTION_GROUP}"
@@ -167,7 +171,7 @@ do
 		--header "X-API-Token: ${appcenter_api_token}" \
 		--silent --show-error \
 		--output /dev/stderr --write-out "%{http_code}" \
-		-d "{ \"destination_name\": \"${DISTRIBUTION_GROUP}\", \"release_notes\": \"${release_notes:-}\", \"notify_testers\": ${notify_testers:-true}}" \
+		-d "{ \"destination_name\": \"${DISTRIBUTION_GROUP}\", \"release_notes\": \"${RELEASE_NOTES_SANITIZED:-}\", \"notify_testers\": ${notify_testers:-true}}" \
 		"https://api.appcenter.ms/v0.1/apps/${appcenter_org}/${appcenter_name}/releases/${RELEASE_ID}" \
 		2> "${TMPFILE}")
 

--- a/test.sh
+++ b/test.sh
@@ -25,6 +25,13 @@ export DISTRIBUTION_GROUPS=x-test-group-1
 export NOTIFY_TESTERS=false
 bitrise run test
 
+echo "INFO: testing to 1 group, no notifications, multi-line release notes"
+export DISTRIBUTION_GROUPS=x-test-group-1
+export NOTIFY_TESTERS=false
+export RELEASE_NOTES="Hey there, just testing a 
+newline"
+bitrise run test
+
 echo "INFO: testing to second group, w/notifications and release notes"
 export DISTRIBUTION_GROUPS=x-test-group-2
 export NOTIFY_TESTERS=true

--- a/test.sh
+++ b/test.sh
@@ -25,10 +25,8 @@ export DISTRIBUTION_GROUPS=x-test-group-1
 export NOTIFY_TESTERS=false
 bitrise run test
 
-echo "INFO: testing to 1 group, no notifications, multi-line release notes"
-export DISTRIBUTION_GROUPS=x-test-group-1
-export NOTIFY_TESTERS=false
-export RELEASE_NOTES="Hey there, just testing a 
+echo "INFO: testing multi-line release notes"
+export RELEASE_NOTES="Hey there, just testing a \n
 newline"
 bitrise run test
 


### PR DESCRIPTION
Fixes https://github.com/fileformat/bitrise-step-appcenter-app-release/issues/15

The trimming of release notes could cause side effects and might be better off behind a flag (`sanitize_release_notes` maybe?), but this should solve the very common case where a GitHub commit message is the release note and it contains line breaks.
  