### PR TITLE
Adding RELEASEID to environment variables and outputs.

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -179,4 +179,15 @@ do
 	rm "${TMPFILE}"
 done
 
+echo_info "Adding release id to environment variables"
+envman add --key RELEASEID --value $RELEASE_ID
+
+releaseId=$(envman run bash -c 'echo "Environment test: $RELEASEID"')
+
+if [[ -z "$releaseId" ]]; then
+	echo_fail "Environment variable RELEASEID was not set!"
+else
+  echo_details "Release ID ${releaseId} added to environment variables"
+fi
+
 echo_done "Completed AppCenter app upload at $(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/step.yml
+++ b/step.yml
@@ -102,3 +102,9 @@ inputs:
       title: "Uploaded build related release notes"
       is_expand: true
       is_required: false
+
+outputs:
+  - RELEASEID:
+    opts:
+      title: "Release ID"
+      description: "The `release_id` of the current release"


### PR DESCRIPTION
I need this to generate links that hit the releases page directly.

`https://appcenter.ms/orgs/{ORGANIZATION}/apps/{APPNAME}/distribute/releases/{RELEASEID}`

Will likely submit another pull request adding this URL as an output.