### PR TITLE
Added AppCenter release details url to environment variables.

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -131,6 +131,9 @@ RELEASE_ID=$(cat "${TMPFILE}" | jq .release_id --raw-output)
 echo_details "result is ${STATUSCODE}: $(cat ${TMPFILE})"
 rm "${TMPFILE}"
 
+DISTRIBUTE_RELEASE_URL="https://appcenter.ms/orgs/${appcenter_org}/apps/${appcenter_name}/distribute/releases/${RELEASE_ID}"
+envman add --key APPCENTER_DISTRIBUTE_RELEASE_URL --value "${DISTRIBUTE_RELEASE_URL}"
+
 IFS=', ' read -r -a DISTRIBUTION_GROUPS <<< ${distribution_groups:-}
 if [ ${#DISTRIBUTION_GROUPS[@]} -eq 0 ]
 then


### PR DESCRIPTION
I need this to generate links that hit the distribute release page directly. Existing URL's go directly to the download.

https://appcenter.ms/orgs/{ORGANIZATION}/apps/{APPNAME}/distribute/releases/{RELEASEID}