### PR TITLE
spaces are allowed in app center group ids

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -133,7 +133,7 @@ RELEASE_ID=$(cat "${TMPFILE}" | jq .release_id --raw-output)
 echo_details "result is ${STATUSCODE}: $(cat ${TMPFILE})"
 rm "${TMPFILE}"
 
-IFS=', ' read -r -a DISTRIBUTION_GROUPS <<< ${distribution_groups:-}
+IFS=',' read -r -a DISTRIBUTION_GROUPS <<< ${distribution_groups:-}
 if [ ${#DISTRIBUTION_GROUPS[@]} -eq 0 ]
 then
 echo_info "Retrieving distribution groups for ${appcenter_name}"


### PR DESCRIPTION
Before `distribution_groups="test group 1,test group 2"` would try to distribute to the groups `test` `group` `1` `test` `group` and `2`, yet `test group 1` is a legal app center group name.