### PR TITLE
Adds information in README about appcenter_name and appcenter_org

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This is a "step" for the [Bitrise](https://www.bitrise.io/) CI/CD service that p
 * appcenter_org - AppCenter organization that owns the app
 * artifact_path - the full path of the `.ipa` or `.apk` file
 
+You need to extract your appcenter_name and appcenter_org from the url. Follow [this link](https://docs.microsoft.com/en-us/appcenter/api-docs/#find-your-app-center-app-name-and-owner-name) for more information.
+
 ## Optional variables
 
 * release_notes - release notes to include with this release


### PR DESCRIPTION
I wasted a few minutes because I was naive in thinking that appcenter_org and appcenter_name was literally the name 😂.

I hope this can save some minutes for the next dev that is crazy like me.