### PR TITLE
appcenter  new upload url

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -85,7 +85,7 @@ STATUSCODE=$(curl \
 	--header "X-API-Token: ${appcenter_api_token}" \
 	--silent --show-error \
 	--output /dev/stderr --write-out "%{http_code}" \
-	"https://api.appcenter.ms/v0.1/apps/${appcenter_org}/${appcenter_name}/release_uploads" \
+	"https://api.appcenter.ms/v0.1/apps/${appcenter_org}/${appcenter_name}/uploads/releases" \
 	2> "${TMPFILE}")
 if [ "${STATUSCODE}" -ne "201" ]
 then


### PR DESCRIPTION
I deploy my app with appcenter-app-release 1.x.x

and receive an error message like this

```
API call failed with 404: {"message":"Resource not found: /v0.1/apps/xxxxx/xxxxxxx/release_uploads
```

Microsoft appcenter has changed the APIs

Look at [this document](https://openapi.appcenter.ms/) about release apps

I think this is `/v0.1/apps/xxxxx/xxxxxxx/uploads/releases` now, Right?